### PR TITLE
fix: build should run on PR and push to `master` only now

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -1,6 +1,12 @@
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
To avoid wasting Github workload, action runs only on push to `master`.

You can also disable actions on your fork completely to not bother with them. For that, go into your fork `Settings` -> `Actions` -> `Disable Actions`.